### PR TITLE
Use r-strings for latex commands

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,6 +5,13 @@ Elemental documentation and webpage
 The repository contains the source for the pages at
 http://libelemental.org.
 
+* How to: set up python environment
+  ::
+
+    pip install sphinx sphinx_rtd_theme spinx-serve
+
+  This will install python dependencies.
+
 * How to: generate web pages
   ::
 
@@ -42,3 +49,10 @@ http://libelemental.org.
 
 * NOTE: This documentation was forked from fenics-web, which may be found at
   https://bitbucket.org/fenics-project/fenics-web.
+
+* How to preview on your local machine
+  ::
+
+    sphinx-serve -b build
+
+  This will host a webserver containing the rendered webpages

--- a/source/doc-0.81/conf.py
+++ b/source/doc-0.81/conf.py
@@ -220,11 +220,11 @@ latex_logo = '../_themes/elemental/static/elemental.png'
 # If false, no module index is generated.
 #latex_use_modindex = True
 
-latex_elements = {'fontpkg': '\\usepackage{mathpazo}',
+latex_elements = {'fontpkg': r'\usepackage{mathpazo}',
                   'pointsize': '11pt',
                   'papersize': 'a4paper',
                   'fontenc': '',
-                  'preamble': '\\usepackage{amssymb} \\usepackage{stmaryrd}'}
+                  'preamble': r'\usepackage{amssymb} \usepackage{stmaryrd}'}
 
 # Parameters affecting the LaTeX PNGs in the HTML files
 pngmath_latex_preamble = r" \usepackage{stmaryrd} "

--- a/source/doc-0.81/conf.py
+++ b/source/doc-0.81/conf.py
@@ -220,11 +220,11 @@ latex_logo = '../_themes/elemental/static/elemental.png'
 # If false, no module index is generated.
 #latex_use_modindex = True
 
-latex_elements = {'fontpkg': '\usepackage{mathpazo}',
+latex_elements = {'fontpkg': '\\usepackage{mathpazo}',
                   'pointsize': '11pt',
                   'papersize': 'a4paper',
                   'fontenc': '',
-                  'preamble': '\usepackage{amssymb} \usepackage{stmaryrd}'}
+                  'preamble': '\\usepackage{amssymb} \\usepackage{stmaryrd}'}
 
 # Parameters affecting the LaTeX PNGs in the HTML files
 pngmath_latex_preamble = r" \usepackage{stmaryrd} "

--- a/source/doc-0.82-p1/conf.py
+++ b/source/doc-0.82-p1/conf.py
@@ -220,11 +220,11 @@ latex_logo = '../_themes/elemental/static/elemental.png'
 # If false, no module index is generated.
 #latex_use_modindex = True
 
-latex_elements = {'fontpkg': '\\usepackage{mathpazo}',
+latex_elements = {'fontpkg': r'\usepackage{mathpazo}',
                   'pointsize': '11pt',
                   'papersize': 'a4paper',
                   'fontenc': '',
-                  'preamble': '\\usepackage{amssymb} \\usepackage{stmaryrd}'}
+                  'preamble': r'\usepackage{amssymb} \usepackage{stmaryrd}'}
 
 # Parameters affecting the LaTeX PNGs in the HTML files
 pngmath_latex_preamble = r" \usepackage{stmaryrd} "

--- a/source/doc-0.82-p1/conf.py
+++ b/source/doc-0.82-p1/conf.py
@@ -220,11 +220,11 @@ latex_logo = '../_themes/elemental/static/elemental.png'
 # If false, no module index is generated.
 #latex_use_modindex = True
 
-latex_elements = {'fontpkg': '\usepackage{mathpazo}',
+latex_elements = {'fontpkg': '\\usepackage{mathpazo}',
                   'pointsize': '11pt',
                   'papersize': 'a4paper',
                   'fontenc': '',
-                  'preamble': '\usepackage{amssymb} \usepackage{stmaryrd}'}
+                  'preamble': '\\usepackage{amssymb} \\usepackage{stmaryrd}'}
 
 # Parameters affecting the LaTeX PNGs in the HTML files
 pngmath_latex_preamble = r" \usepackage{stmaryrd} "

--- a/source/doc-0.82/conf.py
+++ b/source/doc-0.82/conf.py
@@ -220,11 +220,11 @@ latex_logo = '../_themes/elemental/static/elemental.png'
 # If false, no module index is generated.
 #latex_use_modindex = True
 
-latex_elements = {'fontpkg': '\\usepackage{mathpazo}',
+latex_elements = {'fontpkg': r'\usepackage{mathpazo}',
                   'pointsize': '11pt',
                   'papersize': 'a4paper',
                   'fontenc': '',
-                  'preamble': '\\usepackage{amssymb} \\usepackage{stmaryrd}'}
+                  'preamble': r'\usepackage{amssymb} \usepackage{stmaryrd}'}
 
 # Parameters affecting the LaTeX PNGs in the HTML files
 pngmath_latex_preamble = r" \usepackage{stmaryrd} "

--- a/source/doc-0.82/conf.py
+++ b/source/doc-0.82/conf.py
@@ -220,11 +220,11 @@ latex_logo = '../_themes/elemental/static/elemental.png'
 # If false, no module index is generated.
 #latex_use_modindex = True
 
-latex_elements = {'fontpkg': '\usepackage{mathpazo}',
+latex_elements = {'fontpkg': '\\usepackage{mathpazo}',
                   'pointsize': '11pt',
                   'papersize': 'a4paper',
                   'fontenc': '',
-                  'preamble': '\usepackage{amssymb} \usepackage{stmaryrd}'}
+                  'preamble': '\\usepackage{amssymb} \\usepackage{stmaryrd}'}
 
 # Parameters affecting the LaTeX PNGs in the HTML files
 pngmath_latex_preamble = r" \usepackage{stmaryrd} "

--- a/source/doc-0.83/conf.py
+++ b/source/doc-0.83/conf.py
@@ -220,11 +220,11 @@ latex_logo = '../_themes/elemental/static/elemental.png'
 # If false, no module index is generated.
 #latex_use_modindex = True
 
-latex_elements = {'fontpkg': '\\usepackage{mathpazo}',
+latex_elements = {'fontpkg': r'\usepackage{mathpazo}',
                   'pointsize': '11pt',
                   'papersize': 'a4paper',
                   'fontenc': '',
-                  'preamble': '\\usepackage{amssymb} \\usepackage{stmaryrd}'}
+                  'preamble': r'\usepackage{amssymb} \usepackage{stmaryrd}'}
 
 # Parameters affecting the LaTeX PNGs in the HTML files
 pngmath_latex_preamble = r" \usepackage{stmaryrd} "

--- a/source/doc-0.83/conf.py
+++ b/source/doc-0.83/conf.py
@@ -220,11 +220,11 @@ latex_logo = '../_themes/elemental/static/elemental.png'
 # If false, no module index is generated.
 #latex_use_modindex = True
 
-latex_elements = {'fontpkg': '\usepackage{mathpazo}',
+latex_elements = {'fontpkg': '\\usepackage{mathpazo}',
                   'pointsize': '11pt',
                   'papersize': 'a4paper',
                   'fontenc': '',
-                  'preamble': '\usepackage{amssymb} \usepackage{stmaryrd}'}
+                  'preamble': '\\usepackage{amssymb} \\usepackage{stmaryrd}'}
 
 # Parameters affecting the LaTeX PNGs in the HTML files
 pngmath_latex_preamble = r" \usepackage{stmaryrd} "

--- a/source/doc-0.84/conf.py
+++ b/source/doc-0.84/conf.py
@@ -220,11 +220,11 @@ latex_logo = '../_themes/elemental/static/elemental.png'
 # If false, no module index is generated.
 #latex_use_modindex = True
 
-latex_elements = {'fontpkg': '\\usepackage{mathpazo}',
+latex_elements = {'fontpkg': r'\usepackage{mathpazo}',
                   'pointsize': '11pt',
                   'papersize': 'a4paper',
                   'fontenc': '',
-                  'preamble': '\\usepackage{amssymb} \\usepackage{stmaryrd}'}
+                  'preamble': r'\usepackage{amssymb} \usepackage{stmaryrd}'}
 
 # Parameters affecting the LaTeX PNGs in the HTML files
 pngmath_latex_preamble = r" \usepackage{stmaryrd} "

--- a/source/doc-0.84/conf.py
+++ b/source/doc-0.84/conf.py
@@ -220,11 +220,11 @@ latex_logo = '../_themes/elemental/static/elemental.png'
 # If false, no module index is generated.
 #latex_use_modindex = True
 
-latex_elements = {'fontpkg': '\usepackage{mathpazo}',
+latex_elements = {'fontpkg': '\\usepackage{mathpazo}',
                   'pointsize': '11pt',
                   'papersize': 'a4paper',
                   'fontenc': '',
-                  'preamble': '\usepackage{amssymb} \usepackage{stmaryrd}'}
+                  'preamble': '\\usepackage{amssymb} \\usepackage{stmaryrd}'}
 
 # Parameters affecting the LaTeX PNGs in the HTML files
 pngmath_latex_preamble = r" \usepackage{stmaryrd} "

--- a/source/doc-0.85/conf.py
+++ b/source/doc-0.85/conf.py
@@ -220,11 +220,11 @@ latex_logo = '../_themes/elemental/static/elemental.png'
 # If false, no module index is generated.
 #latex_use_modindex = True
 
-latex_elements = {'fontpkg': '\\usepackage{mathpazo}',
+latex_elements = {'fontpkg': r'\usepackage{mathpazo}',
                   'pointsize': '11pt',
                   'papersize': 'a4paper',
                   'fontenc': '',
-                  'preamble': '\\usepackage{amssymb} \\usepackage{stmaryrd}'}
+                  'preamble': r'\usepackage{amssymb} \usepackage{stmaryrd}'}
 
 # Parameters affecting the LaTeX PNGs in the HTML files
 pngmath_latex_preamble = r" \usepackage{stmaryrd} "

--- a/source/doc-0.85/conf.py
+++ b/source/doc-0.85/conf.py
@@ -220,11 +220,11 @@ latex_logo = '../_themes/elemental/static/elemental.png'
 # If false, no module index is generated.
 #latex_use_modindex = True
 
-latex_elements = {'fontpkg': '\usepackage{mathpazo}',
+latex_elements = {'fontpkg': '\\usepackage{mathpazo}',
                   'pointsize': '11pt',
                   'papersize': 'a4paper',
                   'fontenc': '',
-                  'preamble': '\usepackage{amssymb} \usepackage{stmaryrd}'}
+                  'preamble': '\\usepackage{amssymb} \\usepackage{stmaryrd}'}
 
 # Parameters affecting the LaTeX PNGs in the HTML files
 pngmath_latex_preamble = r" \usepackage{stmaryrd} "

--- a/source/doc-dev/conf.py
+++ b/source/doc-dev/conf.py
@@ -224,11 +224,11 @@ latex_logo = '../_themes/elemental/static/elemental.png'
 # If false, no module index is generated.
 #latex_use_modindex = True
 
-latex_elements = {'fontpkg': '\\usepackage{mathpazo}',
+latex_elements = {'fontpkg': r'\usepackage{mathpazo}',
                   'pointsize': '11pt',
                   'papersize': 'a4paper',
                   'fontenc': '',
-                  'preamble': '\\usepackage{amssymb} \\usepackage{stmaryrd}'}
+                  'preamble': r'\usepackage{amssymb} \usepackage{stmaryrd}'}
 
 # Parameters affecting the LaTeX PNGs in the HTML files
 pngmath_latex_preamble = r" \usepackage{stmaryrd} "

--- a/source/doc-dev/conf.py
+++ b/source/doc-dev/conf.py
@@ -224,11 +224,11 @@ latex_logo = '../_themes/elemental/static/elemental.png'
 # If false, no module index is generated.
 #latex_use_modindex = True
 
-latex_elements = {'fontpkg': '\usepackage{mathpazo}',
+latex_elements = {'fontpkg': '\\usepackage{mathpazo}',
                   'pointsize': '11pt',
                   'papersize': 'a4paper',
                   'fontenc': '',
-                  'preamble': '\usepackage{amssymb} \usepackage{stmaryrd}'}
+                  'preamble': '\\usepackage{amssymb} \\usepackage{stmaryrd}'}
 
 # Parameters affecting the LaTeX PNGs in the HTML files
 pngmath_latex_preamble = r" \usepackage{stmaryrd} "

--- a/source/main/conf.py
+++ b/source/main/conf.py
@@ -224,11 +224,11 @@ latex_logo = '../_themes/elemental/static/elemental.png'
 # If false, no module index is generated.
 #latex_use_modindex = True
 
-latex_elements = {'fontpkg': '\\usepackage{mathpazo}',
+latex_elements = {'fontpkg': r'\usepackage{mathpazo}',
                   'pointsize': '11pt',
                   'papersize': 'a4paper',
                   'fontenc': '',
-                  'preamble': '\\usepackage{amssymb} \\usepackage{stmaryrd}'}
+                  'preamble': r'\usepackage{amssymb} \usepackage{stmaryrd}'}
 
 # Parameters affecting the LaTeX PNGs in the HTML files
 pngmath_latex_preamble = r" \usepackage{stmaryrd} "

--- a/source/main/conf.py
+++ b/source/main/conf.py
@@ -224,11 +224,11 @@ latex_logo = '../_themes/elemental/static/elemental.png'
 # If false, no module index is generated.
 #latex_use_modindex = True
 
-latex_elements = {'fontpkg': '\usepackage{mathpazo}',
+latex_elements = {'fontpkg': '\\usepackage{mathpazo}',
                   'pointsize': '11pt',
                   'papersize': 'a4paper',
                   'fontenc': '',
-                  'preamble': '\usepackage{amssymb} \usepackage{stmaryrd}'}
+                  'preamble': '\\usepackage{amssymb} \\usepackage{stmaryrd}'}
 
 # Parameters affecting the LaTeX PNGs in the HTML files
 pngmath_latex_preamble = r" \usepackage{stmaryrd} "


### PR DESCRIPTION
I think this was introduced in python 3: `"\uXYZ"` expects a unicode code for `XYZ`. This will cause problems for strings like `\usepackage` (as used by `conf.py`) as `sepackage` is not a valid unicode character.

This PR uses raw strings `r"..."` which don't have the special `\u` character.

I also updated the readme to include instructions on how to set up the python environment, and how to preview these docs locally.